### PR TITLE
Suggestion: change requirements install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ OneDriveExplorer is a command line and GUI based application for reconstructing 
 This project requires several additiona modules. You can install them with the provided requirements.txt file as follows:
 
 ```bash
-pip3 install -r requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 ## Command line


### PR DESCRIPTION
Suggestion to install via `python3 -m pip` instead of `pip3`. This way you will always use the correct installation (if more versions are installed).